### PR TITLE
Updated url api and allow dynamic url api from settings

### DIFF
--- a/src/Sirene.php
+++ b/src/Sirene.php
@@ -20,7 +20,7 @@ class Sirene
     /**
      * @var string $urlApi the url of API sirene
      */
-    private $urlApi = "https://api.insee.fr/entreprises/sirene/V3";
+    private $urlApi = "https://api.insee.fr/entreprises/sirene";
 
     /**
      * @var string $urlJWT the url for get JWT
@@ -43,6 +43,9 @@ class Sirene
     public function __construct(array $settings = [])
     {
         if (!empty($settings)) {
+            if(isset($settings['url_api']) && is_string($settings['url_api'])) {
+                $this->urlApi = $settings['url_api'];
+            }
             if (isset($settings["secret"]) && is_string($settings["secret"])) {
                 $this->secretKey = $settings["secret"];
                 if (isset($settings["jwt_path"])) {


### PR DESCRIPTION
Hello, this pull request will fix the new url api (again)

It seems that the INSEE website has been making a lot of changes lately.

![image](https://github.com/SimonDevelop/sirene/assets/53140475/03c82a75-5ea7-4f94-bdaa-c84c80c7af02)

From now on we must either use the URL of the latest version each time, or put back the old URL without version (which I imagine should point directly to the latest version).

I put the URL back to default without the version number. I also added the possibility of modifying the URL to point to from the settings. This will avoid having to make a release if it has to be modified again

```php
return new Sirene([
           "url_api" => 'the url',
            "secret" => "secret.....",
            "jwt_path" => 'path...'
        ]);
```